### PR TITLE
fix: Make page default to 1 if its not provided

### DIFF
--- a/src/modules/posts/comments/index.ts
+++ b/src/modules/posts/comments/index.ts
@@ -25,7 +25,7 @@ commentsApp.get("/:postId/comments", jwt, async (c) => {
 
 		const page = schemaValidator({
 			schema: positiveNumberSchema,
-			value: c.req.query("page"),
+			value: c.req.query("page") ?? 1,
 			route: c.req.path,
 		});
 

--- a/src/modules/posts/index.ts
+++ b/src/modules/posts/index.ts
@@ -27,7 +27,7 @@ postsApp.get("/latests", jwt, async (c) => {
 
 		const page = schemaValidator({
 			schema: positiveNumberSchema,
-			value: c.req.query("page"),
+			value: c.req.query("page") ?? 1,
 			route: c.req.path,
 		});
 
@@ -66,7 +66,7 @@ postsApp.get("/:userId/latests", jwt, async (c) => {
 
 		const page = schemaValidator({
 			schema: positiveNumberSchema,
-			value: c.req.query("page"),
+			value: c.req.query("page") ?? 1,
 			route: c.req.path,
 		});
 


### PR DESCRIPTION
This was requiring the page to be provided by the request, but we can just make it default to 1